### PR TITLE
Add test for redeploying workers after broken

### DIFF
--- a/dask_mesos/core.py
+++ b/dask_mesos/core.py
@@ -147,11 +147,11 @@ class FixedScheduler(mesos.interface.Scheduler):
 
             if tasks:
                 driver.launchTasks(offer.id, tasks)
+                logger.info("Launch tasks %s with offer %s",
+                            [t.task_id.value for t in tasks], offer.id.value)
+                logger.debug("Launching tasks %s", tasks)
             else:
                 driver.declineOffer(offer.id)
-            logger.info("Launch tasks %s with offer %s",
-                        [t.task_id.value for t in tasks], offer.id.value)
-            logger.debug("Launching tasks %s", tasks)
 
     def task_info(self, offer):
         task = mesos_pb2.TaskInfo()


### PR DESCRIPTION
This test seems to kill the Mesos master node and I don't know why.  Putting it up here for @quasiben to take a look at the logs once travis.ci runs.

> Scheduler driver bound to loopback interface! Cannot communicate with remote master(s). You might want to set 'LIBPROCESS_IP' environment variable to use a routable IP address.
