### PR TITLE
Remove python 3 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
   include:
     - python: "2.7"
       env: OS=ubuntu-14.04
-    - python: "3.5"
-      env: OS=ubuntu-14.04
 
 env:
   global:
@@ -38,9 +36,6 @@ before_install:
   - docker-compose up -d
   - docker ps -a
   - docker images
-
-install:
-  - which python
 
 script:
   - docker exec -it mesos_master py.test /dask-mesos/dask_mesos/tests -s -vv


### PR DESCRIPTION
Mesos doesn't support Python 3

cc @quasiben is this ok?
